### PR TITLE
Fix input name in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   token:
     description: 'Token for the repo. Can be passed in using {{ secrets.GITHUB_TOKEN }}'
     required: true
-  input_settings:
+  config:
     description: 'JSON with settings as described in the README'
     required: true
 runs:


### PR DESCRIPTION
There is a Github annotation when running this workflow as documented in the README, telling that the inputs are invalid. You can see it in your [own Actions tab.](https://github.com/tiangolo/issue-manager/actions/runs/118474190)

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/861044/83280589-cf365200-a1ce-11ea-87b3-1f2cf5a25947.png">

The action actually uses `input_config` internally which -I think- is to be declared as `config` in the `action.yml` file.

This should fix this annotation.