### PR TITLE
✨ Add configurable reminder before closing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Imagine this JSON config:
         "delay": 691200,
         "message": "Closing after 8 days of waiting for the additional info requested.",
         "reminder": {
-            "delay": "P3D",
+            "before": "P3D",
             "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
         }
     },
@@ -188,7 +188,7 @@ By default it is false, and doesn't remove the label from the issue.
 
 Each label can also define an optional reminder with:
 
-* `delay`: How long before the issue/PR would be closed to send the reminder.
+* `before`: How long before the issue/PR would be closed to send the reminder.
   Must be shorter than the main `delay`.
   Supports ISO 8601 durations (e.g. `P3D`) or seconds.
 * `message`: The text to post as a comment.
@@ -202,7 +202,7 @@ Example:
     "delay": 691200,
     "message": "Closing after 8 days of waiting for the additional info requested.",
     "reminder": {
-        "delay": "P3D",
+        "before": "P3D",
         "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
     }
 }
@@ -276,7 +276,7 @@ jobs:
                     "delay": 691200,
                     "message": "Closing after 8 days of waiting for the additional info requested.",
                     "reminder": {
-                        "delay": "P3D",
+                        "before": "P3D",
                         "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
                     }
                 }
@@ -357,7 +357,7 @@ jobs:
                     "remove_label_on_comment": true,
                     "remove_label_on_close": true,
                     "reminder": {
-                        "delay": "P3D",
+                        "before": "P3D",
                         "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Imagine this JSON config:
     },
     "waiting": {
         "delay": 691200,
-        "message": "Closing after 8 days of waiting for the additional info requested."
+        "message": "Closing after 8 days of waiting for the additional info requested.",
+        "reminder": {
+            "delay": "P3D",
+            "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
+        }
     },
     "needs-tests": {
       "delay": 691200,
@@ -130,7 +134,13 @@ Then, if:
 * the label was added _after_ the last comment
 * the last comment was addded more than `691200` seconds (8 days) ago
 
-...the GitHub action would close the issue with:
+...the GitHub action would send a reminder on day 5 (because the delay is 8 days and the reminder is set to 3 days before closing):
+
+```markdown
+Heads-up: this will be closed in ~3 days unless there’s new activity.
+```
+
+...and if there is still no activity, it would finally close the issue with:
 
 ```markdown
 Closing after 10 days of waiting for the additional info requested.
@@ -174,6 +184,30 @@ After this GitHub action closes an issue it can also automatically remove the la
 
 By default it is false, and doesn't remove the label from the issue.
 
+### Reminder
+
+Each label can also define an optional reminder with:
+
+* `delay`: How long before the issue/PR would be closed to send the reminder.
+  Must be shorter than the main `delay`.
+  Supports ISO 8601 durations (e.g. `P3D`) or seconds.
+* `message`: The text to post as a comment.
+
+The reminder is just a comment, it does not close the issue or PR.
+
+Example:
+
+```json
+"waiting": {
+    "delay": 691200,
+    "message": "Closing after 8 days of waiting for the additional info requested.",
+    "reminder": {
+        "delay": "P3D",
+        "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
+    }
+}
+
+
 ### Defaults
 
 By default, any config has:
@@ -187,6 +221,7 @@ Assuming the original issue was solved, it will be automatically closed now.
 
 * `remove_label_on_comment`: True. If someone adds a comment after you added the label, it will remove the label from the issue.
 * `remove_label_on_close`: False. After this GitHub action closes the issue it would also remove the label from the issue.
+* `reminder`: None. No reminder will be sent unless explicitly configured.
 
 ### Config in the action
 
@@ -239,7 +274,11 @@ jobs:
                 },
                 "waiting": {
                     "delay": 691200,
-                    "message": "Closing after 8 days of waiting for the additional info requested."
+                    "message": "Closing after 8 days of waiting for the additional info requested.",
+                    "reminder": {
+                        "delay": "P3D",
+                        "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
+                    }
                 }
             }
 ```
@@ -316,7 +355,11 @@ jobs:
                     "delay": 691200,
                     "message": "Closing after 8 days of waiting for the additional info requested.",
                     "remove_label_on_comment": true,
-                    "remove_label_on_close": true
+                    "remove_label_on_close": true,
+                    "reminder": {
+                        "delay": "P3D",
+                        "message": "Heads-up: this will be closed in ~3 days unless there’s new activity."
+                    }
                 }
             }
 ```
@@ -402,6 +445,7 @@ Then, this action, by running every night (or however you configure it) will, fo
 * Check if the issue has one of the configured labels.
 * Check if the label was added _after_ the last comment.
 * If not, remove the label (configurable).
+* If a reminder is configured and its time has arrived, post the reminder comment.
 * Check if the current date-time is more than the configured *delay* to wait for the user to reply back (configurable).
 * Then, if all that matches, it will add a comment with a message (configurable).
 * And then it will close the issue.

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,9 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  # TODO: fix this
+  # image: 'Dockerfile'
+  image: base.dockerfile
 branding:
   icon: 'check-circle'  
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -10,9 +10,7 @@ inputs:
     required: true
 runs:
   using: 'docker'
-  # TODO: fix this
-  # image: 'Dockerfile'
-  image: base.dockerfile
+  image: 'Dockerfile'
 branding:
   icon: 'check-circle'  
   color: 'green'

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,11 @@ from pydantic_settings import BaseSettings
 REMINDER_MARKER = "<!-- reminder -->"
 
 
+class Reminder(BaseModel):
+    message: str = "This issue will be closed automatically in 1 day if no further activity."
+    delay: timedelta = timedelta(days=1)
+
+
 class KeywordMeta(BaseModel):
     delay: timedelta = timedelta(days=10)
     message: str = (
@@ -22,8 +27,7 @@ class KeywordMeta(BaseModel):
     )
     remove_label_on_comment: bool = True
     remove_label_on_close: bool = False
-    remind_before_close_delay: Optional[timedelta] = None
-    remind_before_close_message: str = ""
+    reminder: Optional[Reminder] = None
 
 
 class Settings(BaseSettings):
@@ -138,7 +142,8 @@ def close_issue(
 
 
 def send_reminder(*, issue: Issue, keyword_meta: KeywordMeta) -> None:
-    message = keyword_meta.remind_before_close_message
+    assert keyword_meta.reminder is not None
+    message = keyword_meta.reminder.message
     logging.info(f"Send reminder: #{issue.number} with message: {message}")
     issue.create_comment(f"{REMINDER_MARKER}\n{message}")
 
@@ -162,12 +167,12 @@ def process_issue(*, issue: Issue, settings: Settings) -> None:
             )
             # Check if we need to send a reminder
             scheduled_close_date = keyword_event.created_at + keyword_meta.delay
-            remind = False
-            if keyword_meta.remind_before_close_delay:
+            need_send_reminder = False
+            if keyword_meta.reminder and keyword_meta.reminder.delay:
                 remind_time = (  # Time point after which we should send reminder
-                    scheduled_close_date - keyword_meta.remind_before_close_delay
+                    scheduled_close_date - keyword_meta.reminder.delay
                 )
-                remind = (
+                need_send_reminder = (
                     (now > remind_time)  # It's time to send reminder
                     and (  # .. and it hasn't been sent yet
                         not last_reminder_date or (last_reminder_date < remind_time)
@@ -181,7 +186,7 @@ def process_issue(*, issue: Issue, settings: Settings) -> None:
                 if keyword_meta.remove_label_on_comment:
                     logging.info(f'Removing label: "{keyword}"')
                     issue.remove_from_labels(keyword)
-            elif remind:
+            elif need_send_reminder:
                 send_reminder(issue=issue, keyword_meta=keyword_meta)
                 break
             elif closable_delay:

--- a/schema.json
+++ b/schema.json
@@ -33,6 +33,17 @@
                 "title": "Remove Label On Close",
                 "default": false,
                 "type": "boolean"
+            },
+            "remind_before_close_delay": {
+                "title": "Delay",
+                "default": null,
+                "type": "number",
+                "format": "time-delta"
+            },
+            "remind_before_close_message": {
+                "title": "Message",
+                "default": "",
+                "type": "string"
             }
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -34,16 +34,22 @@
                 "default": false,
                 "type": "boolean"
             },
-            "remind_before_close_delay": {
-                "title": "Delay",
-                "default": null,
-                "type": "number",
-                "format": "time-delta"
-            },
-            "remind_before_close_message": {
-                "title": "Message",
-                "default": "",
-                "type": "string"
+            "reminder": {
+                "title": "Reminder",
+                "type": "object",
+                "properties": {
+                    "delay": {
+                        "title": "Delay",
+                        "default": 86400.0,
+                        "type": "number",
+                        "format": "time-delta"
+                    },
+                    "message": {
+                        "title": "Message",
+                        "default": "This issue will be closed automatically in 1 day if no further activity.",
+                        "type": "string"
+                    }
+                }
             }
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -38,15 +38,15 @@
                 "title": "Reminder",
                 "type": "object",
                 "properties": {
-                    "delay": {
-                        "title": "Delay",
+                    "before": {
+                        "title": "Before",
                         "default": 86400.0,
                         "type": "number",
                         "format": "time-delta"
                     },
                     "message": {
                         "title": "Message",
-                        "default": "This issue will be closed automatically in 1 day if no further activity.",
+                        "default": "This will be closed automatically soon if there's no further activity.",
                         "type": "string"
                     }
                 }


### PR DESCRIPTION
This PR adds the ability to configure sending reminder some time before closing the issue so that to make sure the user hasn't missed previous notification.

Changes are not braking (reminder disabled by default).


**ToDo:**

- [x] Update Readme
