### PR TITLE
👷 Update issue-manager to 0.8.0

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -22,6 +22,6 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1
+      - uses: tiangolo/issue-manager@48bacd85fb842cc27efee25e834edb00aad8f263 # 0.8.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request

Updates the Issue Manager workflow to pin tiangolo/issue-manager to the released 0.8.0 commit.

## Description

I'm seeing [some failures](https://github.com/browniebroke/django-remake-migrations/actions/runs/28191973724/job/83508631465) on my repos when using 0.8.0 when I noticed that this repo itself isn't using the latest version.

```
Traceback (most recent call last):
  File "/code/app/main.py", line 5, in <module>
    from typing_extensions import Literal
ModuleNotFoundError: No module named 'typing_extensions'
```

Opened this in an attempt to get the failure here but then I realised that it doesn't trigger on pull request events... 

## AI Disclaimer

No AI use, simple version bump.

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [ ] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
