### PR TITLE
🐛 Run action on its baked-in Python instead of uv run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ COPY ./app /code/app
 
 ENV PYTHONPATH=/code/app
 
-CMD ["uv", "run", "python", "/code/app/main.py"]
+# Use the image's baked-in venv directly. `uv run` would execute in the mounted
+# consumer repo and would use its pyproject.toml.
+CMD ["/code/.venv/bin/python", "/code/app/main.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN uv sync --locked
 
 COPY ./app /code/app
 
-ENV PYTHONPATH=/code/app
+ENV PYTHONPATH=/code/app \
+    PATH="/code/.venv/bin:$PATH"
 
-# Use the image's baked-in venv directly. `uv run` would execute in the mounted
-# consumer repo and would use its pyproject.toml.
-CMD ["/code/.venv/bin/python", "/code/app/main.py"]
+# Put the image's baked-in venv first on PATH. `uv run` would execute in the
+# mounted consumer repo and would use its pyproject.toml.
+CMD ["python", "/code/app/main.py"]


### PR DESCRIPTION
## Description

Latest version of `issue-manager` is currently failing with:
```
warning: `--no-dev` has no effect when used outside of a project
Traceback (most recent call last):
  File "/code/app/main.py", line 5, in <module>
    from typing_extensions import Literal
ModuleNotFoundError: No module named 'typing_extensions'
```

That's because GH workflow overrides the workdir when it runs the action's container, and then `uv run` command in `CMD RUN` looks for `pyproject.toml` in that workdir instead of `code/`. So, the venv created on previous step is ignored and `uv` is trying to create new venv in current working directory (using the `pyproject.toml` from it, which is usually absent as workflow doesn't use `actions/checkout`).

The solution is the same as in https://github.com/tiangolo/latest-changes/pull/121 for [tiangolo/latest-changes](https://github.com/tiangolo/latest-changes) - use `/code/.venv/bin/python` instead of `uv run`

## AI Disclaimer

Fix is generated by Claude Opus 4.8 (1M context), then I manually reviewed it

</details>

## Checklist

- [ ] This PR is an obvious typo fix, or it links to a GitHub Discussion for the proposed code change.
- [ ] I added tests for the change.
- [ ] The new or updated tests fail on the main branch and pass on this PR.
- [x] Coverage stays at 100%.
- [ ] The documentation explains the change if needed.
