### PR TITLE
👷 Fix latest-changes checkout target

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.repository.default_branch }}
           token: ${{ secrets.ISSUE_MANAGER_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
           persist-credentials: true # required by tiangolo/latest-changes
       - uses: tiangolo/latest-changes@c9b73efbc8992ef1a401e4235ea307a8ca8a724b # 0.6.1


### PR DESCRIPTION
## What changed

- Configure the `latest-changes` workflow checkout step to use the repository default branch explicitly.
- This keeps `pull_request_target` runs on trusted base-repository code when `actions/checkout@v7` is used.

## Why

`actions/checkout@v7` refuses fork PR code in trusted `pull_request_target` contexts. For merged PR release-note workflows, the safe target is the base repository default branch.

## Validation

- Ran `git diff --check` for the changed workflow.
- Verified the pattern end to end in `tiangolo/sandbox`.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
